### PR TITLE
Suppress -Xlint:unchecked compile warning output

### DIFF
--- a/android/src/main/java/io/github/edufolly/fluttermobilevision/ui/GraphicOverlay.java
+++ b/android/src/main/java/io/github/edufolly/fluttermobilevision/ui/GraphicOverlay.java
@@ -46,6 +46,7 @@ import java.util.Vector;
  * from the preview's coordinate system to the view coordinate system.</li>
  * </ol>
  */
+@SuppressWarnings("unchecked")
 public class GraphicOverlay<T extends GraphicOverlay.Graphic> extends View {
     private final Object lock = new Object();
     private int previewWidth;


### PR DESCRIPTION
This fixes #18.

Build output before this PR (four red lines):

    $ flutter build apk
    Running "flutter packages get" in example...                 4.1s
    Initializing gradle...                                      20.4s
    Resolving dependencies...                                   53.8s
    Gradle task 'assembleRelease'...                                 
    Note: Some input files use or override a deprecated API.
    Note: Recompile with -Xlint:deprecation for details.
    Note: .../flutter_mobile_vision/android/src/main/java/io/github/edufolly/fluttermobilevision/ui/GraphicOverlay.java uses unchecked or unsafe operations.
    Note: Recompile with -Xlint:unchecked for details.
    Calling mockable JAR artifact transform to create file: $HOME/.gradle/caches/transforms-1/files-1.1/android.jar/7f4241fd836779c943b0127f9cb8af39/android.jar with input $HOME/Library/Android/sdk/platforms/android-27/android.jar
    Gradle task 'assembleRelease'... Done                       75.3s
    Built build/app/outputs/apk/release/app-release.apk (7.2MB).

Build output after this PR (two red lines):

    $ flutter build apk
    Initializing gradle...                                       2.7s
    Resolving dependencies...                                    2.4s
    Gradle task 'assembleRelease'...                                 
    Note: Some input files use or override a deprecated API.
    Note: Recompile with -Xlint:deprecation for details.
    Gradle task 'assembleRelease'... Done                       46.6s
    Built build/app/outputs/apk/release/app-release.apk (7.2MB).
