### PR TITLE
Add Optional ScanArea GraphicOverlay and Detection Filtering for OCR

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.android.tools.build:gradle:4.0.1'
     }
 }
 

--- a/android/src/main/java/io/github/edufolly/fluttermobilevision/FlutterMobileVisionDelegate.java
+++ b/android/src/main/java/io/github/edufolly/fluttermobilevision/FlutterMobileVisionDelegate.java
@@ -52,6 +52,8 @@ public class FlutterMobileVisionDelegate
     private boolean showText = false;
     private int previewWidth = 640;
     private int previewHeight = 480;
+    private int scanAreaWidth = 0;
+    private int scanAreaHeight = 0;
     private int camera = CameraSource.CAMERA_FACING_BACK;
     private float fps = 15.0f;
 
@@ -188,6 +190,14 @@ public class FlutterMobileVisionDelegate
             previewHeight = (int) arguments.get("previewHeight");
         }
 
+        if (arguments.containsKey("scanAreaWidth")) {
+            scanAreaWidth = (int) arguments.get("scanAreaWidth");
+        }
+
+        if (arguments.containsKey("scanAreaHeight")) {
+            scanAreaHeight = (int) arguments.get("scanAreaHeight");
+        }
+
         if (arguments.containsKey("camera")) {
             camera = (int) arguments.get("camera");
         }
@@ -226,6 +236,8 @@ public class FlutterMobileVisionDelegate
         intent.putExtra(AbstractCaptureActivity.SHOW_TEXT, showText);
         intent.putExtra(AbstractCaptureActivity.PREVIEW_WIDTH, previewWidth);
         intent.putExtra(AbstractCaptureActivity.PREVIEW_HEIGHT, previewHeight);
+        intent.putExtra(AbstractCaptureActivity.SCAN_AREA_WIDTH, scanAreaWidth);
+        intent.putExtra(AbstractCaptureActivity.SCAN_AREA_HEIGHT, scanAreaHeight);
         intent.putExtra(AbstractCaptureActivity.CAMERA, camera);
         intent.putExtra(AbstractCaptureActivity.FPS, fps);
 

--- a/android/src/main/java/io/github/edufolly/fluttermobilevision/ocr/OcrCaptureActivity.java
+++ b/android/src/main/java/io/github/edufolly/fluttermobilevision/ocr/OcrCaptureActivity.java
@@ -25,7 +25,7 @@ public final class OcrCaptureActivity extends AbstractCaptureActivity<OcrGraphic
         TextRecognizer textRecognizer = new TextRecognizer.Builder(context)
                 .build();
 
-        OcrTrackerFactory ocrTrackerFactory = new OcrTrackerFactory(graphicOverlay, showText);
+        OcrTrackerFactory ocrTrackerFactory = new OcrTrackerFactory(graphicOverlay, showText, scanAreaHeight, scanAreaWidth, scanAreaOverlay);
 
         textRecognizer.setProcessor(
                 new MultiProcessor.Builder<>(ocrTrackerFactory).build());

--- a/android/src/main/java/io/github/edufolly/fluttermobilevision/ocr/OcrGraphicTracker.java
+++ b/android/src/main/java/io/github/edufolly/fluttermobilevision/ocr/OcrGraphicTracker.java
@@ -29,8 +29,13 @@ class OcrGraphicTracker extends Tracker<TextBlock> {
 
     @Override
     public void onUpdate(Detector.Detections<TextBlock> detections, TextBlock textBlock) {
-        // Only one ScanAreaGraphic exists in scanAreaOverlay
+        // Only one ScanAreaGraphic exists in scanAreaOverlay (if scanArea specified by flutter developer)
         ScanAreaGraphic scanAreaGraphic = this.scanAreaOverlay.getBest(0,0);
+        if (scanAreaGraphic == null) {
+          overlay.add(graphic);
+          graphic.updateItem(textBlock);
+          return;
+        }
         // Translate textBlock to scanAreaOverlay's scale 
         RectF scaledTextBlockRectF = scanAreaGraphic.translateRect(new RectF(textBlock.getBoundingBox()));
         // // Check that detected text fits within scan area in order to add

--- a/android/src/main/java/io/github/edufolly/fluttermobilevision/ocr/OcrGraphicTracker.java
+++ b/android/src/main/java/io/github/edufolly/fluttermobilevision/ocr/OcrGraphicTracker.java
@@ -4,16 +4,22 @@ import com.google.android.gms.vision.Detector;
 import com.google.android.gms.vision.Tracker;
 import com.google.android.gms.vision.text.TextBlock;
 
+import android.graphics.RectF;
+
 import io.github.edufolly.fluttermobilevision.ui.GraphicOverlay;
+import io.github.edufolly.fluttermobilevision.ui.ScanAreaGraphic;
+
 
 class OcrGraphicTracker extends Tracker<TextBlock> {
 
     private GraphicOverlay<OcrGraphic> overlay;
     private OcrGraphic graphic;
+    private GraphicOverlay<ScanAreaGraphic> scanAreaOverlay;
 
-    public OcrGraphicTracker(GraphicOverlay<OcrGraphic> overlay, OcrGraphic graphic) {
+    public OcrGraphicTracker(GraphicOverlay<OcrGraphic> overlay, OcrGraphic graphic, GraphicOverlay<ScanAreaGraphic> scanAreaOverlay) {
         this.overlay = overlay;
         this.graphic = graphic;
+        this.scanAreaOverlay = scanAreaOverlay;
     }
 
     @Override
@@ -23,8 +29,19 @@ class OcrGraphicTracker extends Tracker<TextBlock> {
 
     @Override
     public void onUpdate(Detector.Detections<TextBlock> detections, TextBlock textBlock) {
-        overlay.add(graphic);
-        graphic.updateItem(textBlock);
+        // Only one ScanAreaGraphic exists in scanAreaOverlay
+        ScanAreaGraphic scanAreaGraphic = this.scanAreaOverlay.getBest(0,0);
+        // Translate textBlock to scanAreaOverlay's scale 
+        RectF scaledTextBlockRectF = scanAreaGraphic.translateRect(new RectF(textBlock.getBoundingBox()));
+        // // Check that detected text fits within scan area in order to add
+        if (scanAreaGraphic.getBoundingBox().contains(scaledTextBlockRectF)) {
+          overlay.add(graphic);
+          graphic.updateItem(textBlock);
+        }
+        // If not, remove potential text graphic from overlay (graphic no longer in scan area)
+        else {
+          overlay.remove(graphic);
+        }
     }
 
     @Override

--- a/android/src/main/java/io/github/edufolly/fluttermobilevision/ocr/OcrTrackerFactory.java
+++ b/android/src/main/java/io/github/edufolly/fluttermobilevision/ocr/OcrTrackerFactory.java
@@ -7,21 +7,28 @@ import com.google.android.gms.vision.Tracker;
 import com.google.android.gms.vision.text.TextBlock;
 
 import io.github.edufolly.fluttermobilevision.ui.GraphicOverlay;
+import io.github.edufolly.fluttermobilevision.ui.ScanAreaGraphic;
 
 public class OcrTrackerFactory implements MultiProcessor.Factory<TextBlock> {
     private GraphicOverlay<OcrGraphic> graphicOverlay;
+    private GraphicOverlay<ScanAreaGraphic> scanAreaOverlay;
     private boolean showText;
+    private int scanAreaHeight;
+    private int scanAreaWidth;
 
-    public OcrTrackerFactory(GraphicOverlay<OcrGraphic> graphicOverlay, boolean showText) {
+    public OcrTrackerFactory(GraphicOverlay<OcrGraphic> graphicOverlay, boolean showText, int scanAreaHeight, int scanAreaWidth, GraphicOverlay<ScanAreaGraphic> scanAreaOverlay) {
         this.graphicOverlay = graphicOverlay;
         this.showText = showText;
+        this.scanAreaHeight = scanAreaHeight;
+        this.scanAreaWidth = scanAreaWidth;
+        this.scanAreaOverlay = scanAreaOverlay;
     }
 
     @Override
     public Tracker<TextBlock> create(TextBlock textBlock) {
         OcrGraphic graphic = new OcrGraphic(graphicOverlay, showText);
         try {
-            return new OcrGraphicTracker(graphicOverlay, graphic);
+            return new OcrGraphicTracker(graphicOverlay, graphic, scanAreaOverlay);
         } catch (Exception ex) {
             Log.d("OcrTrackerFactory", ex.getMessage(), ex);
         }

--- a/android/src/main/java/io/github/edufolly/fluttermobilevision/ui/CameraSourcePreview.java
+++ b/android/src/main/java/io/github/edufolly/fluttermobilevision/ui/CameraSourcePreview.java
@@ -130,7 +130,9 @@ public class CameraSourcePreview extends ViewGroup {
                     scanAreaOverlay.setCameraInfo(max, min, cameraSource.getCameraFacing());
                 }
               ScanAreaGraphic scanAreaGraphic = new ScanAreaGraphic(this.scanAreaOverlay, this.scanAreaHeight, this.scanAreaWidth);
-              scanAreaOverlay.add(scanAreaGraphic);
+              if (this.scanAreaHeight != 0 && this.scanAreaWidth != 0) {
+                  scanAreaOverlay.add(scanAreaGraphic);
+              }
             }
             startRequested = false;
         }

--- a/android/src/main/java/io/github/edufolly/fluttermobilevision/ui/CameraSourcePreview.java
+++ b/android/src/main/java/io/github/edufolly/fluttermobilevision/ui/CameraSourcePreview.java
@@ -28,6 +28,7 @@ import com.google.android.gms.common.images.Size;
 import java.io.IOException;
 
 import io.github.edufolly.fluttermobilevision.util.MobileVisionException;
+import io.github.edufolly.fluttermobilevision.R; // for scan area
 
 public class CameraSourcePreview extends ViewGroup {
     private static final String TAG = "CameraSourcePreview";
@@ -39,6 +40,9 @@ public class CameraSourcePreview extends ViewGroup {
     private CameraSource cameraSource;
 
     private GraphicOverlay overlay;
+    private GraphicOverlay scanAreaOverlay;
+    private int scanAreaHeight;
+    private int scanAreaWidth;
 
     public CameraSourcePreview(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -74,6 +78,15 @@ public class CameraSourcePreview extends ViewGroup {
         start(cameraSource);
     }
 
+    public void start(CameraSource cameraSource, GraphicOverlay overlay, int scanAreaHeight, int scanAreaWidth)
+            throws IOException, SecurityException, MobileVisionException {
+
+        this.overlay = overlay;
+        this.scanAreaHeight = scanAreaHeight;
+        this.scanAreaWidth = scanAreaWidth;
+        start(cameraSource);
+    }
+
     public void stop() {
         if (cameraSource != null) {
             cameraSource.stop();
@@ -102,6 +115,22 @@ public class CameraSourcePreview extends ViewGroup {
                     overlay.setCameraInfo(max, min, cameraSource.getCameraFacing());
                 }
                 overlay.clear();
+            }
+            // Set up separate overlay for scan area
+            this.scanAreaOverlay = findViewById(R.id.scan_area_overlay);
+            if (this.scanAreaOverlay != null) {
+              Size size = cameraSource.getPreviewSize();
+                int min = Math.min(size.getWidth(), size.getHeight());
+                int max = Math.max(size.getWidth(), size.getHeight());
+                if (isPortraitMode()) {
+                    // Swap width and height sizes when in portrait, since it will be rotated by
+                    // 90 degrees
+                    scanAreaOverlay.setCameraInfo(min, max, cameraSource.getCameraFacing());
+                } else {
+                    scanAreaOverlay.setCameraInfo(max, min, cameraSource.getCameraFacing());
+                }
+              ScanAreaGraphic scanAreaGraphic = new ScanAreaGraphic(this.scanAreaOverlay, this.scanAreaHeight, this.scanAreaWidth);
+              scanAreaOverlay.add(scanAreaGraphic);
             }
             startRequested = false;
         }

--- a/android/src/main/java/io/github/edufolly/fluttermobilevision/ui/ScanAreaGraphic.java
+++ b/android/src/main/java/io/github/edufolly/fluttermobilevision/ui/ScanAreaGraphic.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.edufolly.fluttermobilevision.ui;
+
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.RectF;
+import android.graphics.Point;
+
+
+import com.google.android.gms.vision.text.Text;
+import com.google.android.gms.vision.text.TextBlock;
+
+import java.util.List;
+
+import io.github.edufolly.fluttermobilevision.ui.GraphicOverlay;
+
+/**
+ * Graphic instance 
+ */
+public class ScanAreaGraphic extends GraphicOverlay.Graphic {
+
+    private static final int TEXT_COLOR = Color.WHITE;
+    private static final Paint rectPaint = new Paint();
+    private static final Paint textPaint = new Paint();
+
+    static {
+        rectPaint.setColor(TEXT_COLOR);
+        rectPaint.setStyle(Paint.Style.STROKE);
+        rectPaint.setStrokeWidth(4.0f);
+
+        textPaint.setColor(TEXT_COLOR);
+        textPaint.setTextSize(50.0f);
+    }
+
+    private int scanAreaHeight;
+    private int scanAreaWidth;
+
+
+    public ScanAreaGraphic(GraphicOverlay overlay, int scanAreaHeight, int scanAreaWidth) {
+        super(overlay);
+
+        this.scanAreaHeight = scanAreaHeight;
+        this.scanAreaWidth = scanAreaWidth;
+
+        postInvalidate();
+    }
+
+    // Unused
+    public RectF getBoundingBox() {
+        return new RectF();
+    }
+
+    /**
+     * Draws the RectF outlining the scan area
+     */
+    @Override
+    public void draw(Canvas canvas) {
+        int canvasW = canvas.getWidth();
+        int canvasH = canvas.getHeight();
+        Point centerOfCanvas = new Point(canvasW / 2, canvasH / 2);
+        int rectH = this.scanAreaHeight;
+        int rectW = this.scanAreaWidth;
+        int left = centerOfCanvas.x - (rectW / 2);
+        int top = centerOfCanvas.y - (rectH / 2);
+        int right = centerOfCanvas.x + (rectW / 2);
+        int bottom = centerOfCanvas.y + (rectH / 2);
+        RectF rect = new RectF(left, top, right, bottom);
+        canvas.drawRect(rect, rectPaint);
+    }
+}

--- a/android/src/main/java/io/github/edufolly/fluttermobilevision/ui/ScanAreaGraphic.java
+++ b/android/src/main/java/io/github/edufolly/fluttermobilevision/ui/ScanAreaGraphic.java
@@ -49,7 +49,7 @@ public class ScanAreaGraphic extends GraphicOverlay.Graphic {
 
     private int scanAreaHeight;
     private int scanAreaWidth;
-
+    private RectF rect;
 
     public ScanAreaGraphic(GraphicOverlay overlay, int scanAreaHeight, int scanAreaWidth) {
         super(overlay);
@@ -60,9 +60,8 @@ public class ScanAreaGraphic extends GraphicOverlay.Graphic {
         postInvalidate();
     }
 
-    // Unused
     public RectF getBoundingBox() {
-        return new RectF();
+        return this.rect;
     }
 
     /**
@@ -79,7 +78,7 @@ public class ScanAreaGraphic extends GraphicOverlay.Graphic {
         int top = centerOfCanvas.y - (rectH / 2);
         int right = centerOfCanvas.x + (rectW / 2);
         int bottom = centerOfCanvas.y + (rectH / 2);
-        RectF rect = new RectF(left, top, right, bottom);
-        canvas.drawRect(rect, rectPaint);
+        this.rect = new RectF(left, top, right, bottom);
+        canvas.drawRect(this.rect, rectPaint);
     }
 }

--- a/android/src/main/java/io/github/edufolly/fluttermobilevision/util/AbstractCaptureActivity.java
+++ b/android/src/main/java/io/github/edufolly/fluttermobilevision/util/AbstractCaptureActivity.java
@@ -19,6 +19,7 @@ import io.github.edufolly.fluttermobilevision.R;
 import io.github.edufolly.fluttermobilevision.ui.CameraSource;
 import io.github.edufolly.fluttermobilevision.ui.CameraSourcePreview;
 import io.github.edufolly.fluttermobilevision.ui.GraphicOverlay;
+import io.github.edufolly.fluttermobilevision.ui.ScanAreaGraphic;
 
 public abstract class AbstractCaptureActivity<T extends GraphicOverlay.Graphic>
         extends Activity {
@@ -70,6 +71,7 @@ public abstract class AbstractCaptureActivity<T extends GraphicOverlay.Graphic>
 
             preview = findViewById(R.id.preview);
             graphicOverlay = findViewById(R.id.graphic_overlay);
+            scanAreaOverlay = findViewById(R.id.scan_area_overlay);
 
             autoFocus = getIntent().getBooleanExtra(AUTO_FOCUS, false);
             useFlash = getIntent().getBooleanExtra(USE_FLASH, false);
@@ -143,7 +145,7 @@ public abstract class AbstractCaptureActivity<T extends GraphicOverlay.Graphic>
 
         if (cameraSource != null) {
             try {
-                preview.start(cameraSource, graphicOverlay);
+                preview.start(cameraSource, graphicOverlay, scanAreaHeight, scanAreaWidth);
             } catch (IOException e) {
                 cameraSource.release();
                 cameraSource = null;

--- a/android/src/main/java/io/github/edufolly/fluttermobilevision/util/AbstractCaptureActivity.java
+++ b/android/src/main/java/io/github/edufolly/fluttermobilevision/util/AbstractCaptureActivity.java
@@ -43,6 +43,7 @@ public abstract class AbstractCaptureActivity<T extends GraphicOverlay.Graphic>
     protected CameraSource cameraSource;
     protected CameraSourcePreview preview;
     protected GraphicOverlay<T> graphicOverlay;
+    protected GraphicOverlay<ScanAreaGraphic> scanAreaOverlay;
 
     protected GestureDetector gestureDetector;
 

--- a/android/src/main/java/io/github/edufolly/fluttermobilevision/util/AbstractCaptureActivity.java
+++ b/android/src/main/java/io/github/edufolly/fluttermobilevision/util/AbstractCaptureActivity.java
@@ -31,6 +31,8 @@ public abstract class AbstractCaptureActivity<T extends GraphicOverlay.Graphic>
     public static final String SHOW_TEXT = "SHOW_TEXT";
     public static final String PREVIEW_WIDTH = "PREVIEW_WIDTH";
     public static final String PREVIEW_HEIGHT = "PREVIEW_HEIGHT";
+    public static final String SCAN_AREA_WIDTH = "SCAN_AREA_WIDTH";
+    public static final String SCAN_AREA_HEIGHT = "SCAN_AREA_HEIGHT";
     public static final String CAMERA = "CAMERA";
     public static final String FPS = "FPS";
 
@@ -50,6 +52,8 @@ public abstract class AbstractCaptureActivity<T extends GraphicOverlay.Graphic>
     protected boolean showText;
     protected int previewWidth;
     protected int previewHeight;
+    protected int scanAreaWidth;
+    protected int scanAreaHeight;
     protected int camera;
     protected float fps;
 
@@ -74,6 +78,8 @@ public abstract class AbstractCaptureActivity<T extends GraphicOverlay.Graphic>
             showText = getIntent().getBooleanExtra(SHOW_TEXT, false);
             previewWidth = getIntent().getIntExtra(PREVIEW_WIDTH, CameraSource.PREVIEW_WIDTH);
             previewHeight = getIntent().getIntExtra(PREVIEW_HEIGHT, CameraSource.PREVIEW_HEIGHT);
+            scanAreaWidth = getIntent().getIntExtra(SCAN_AREA_WIDTH, 0);
+            scanAreaHeight = getIntent().getIntExtra(SCAN_AREA_HEIGHT, 0);
             camera = getIntent().getIntExtra(CAMERA, CameraSource.CAMERA_FACING_BACK);
             fps = getIntent().getFloatExtra(FPS, 15.0f);
 

--- a/android/src/main/res/layout/capture.xml
+++ b/android/src/main/res/layout/capture.xml
@@ -15,6 +15,10 @@
             android:id="@+id/graphic_overlay"
             android:layout_width="match_parent"
             android:layout_height="match_parent" />
+        <io.github.edufolly.fluttermobilevision.ui.GraphicOverlay
+            android:id="@+id/scan_area_overlay"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
 
     </io.github.edufolly.fluttermobilevision.ui.CameraSourcePreview>
 

--- a/lib/flutter_mobile_vision.dart
+++ b/lib/flutter_mobile_vision.dart
@@ -9,6 +9,7 @@ class FlutterMobileVision {
   static const int CAMERA_FRONT = 1;
 
   static const Size PREVIEW = Size(640, 480);
+  static const Size SCAN_AREA = Size(0, 0);
 
   static final Map<int, List<Size>> _previewSizes = {};
 
@@ -46,6 +47,7 @@ class FlutterMobileVision {
     bool waitTap = false,
     bool showText = false,
     Size preview = PREVIEW,
+    Size scanArea = SCAN_AREA,
     int camera = CAMERA_BACK,
     double fps = 15.0,
   }) async {
@@ -61,6 +63,8 @@ class FlutterMobileVision {
       'showText': showText,
       'previewWidth': preview != null ? preview.width : PREVIEW.width,
       'previewHeight': preview != null ? preview.height : PREVIEW.height,
+      'scanAreaWidth': scanArea != null ? scanArea.width : SCAN_AREA.width,
+      'scanAreaHeight': scanArea != null ? scanArea.height : SCAN_AREA.height,
       'camera': camera,
       'fps': fps,
     };
@@ -80,6 +84,7 @@ class FlutterMobileVision {
     bool waitTap = false,
     bool showText = true,
     Size preview = PREVIEW,
+    Size scanArea = SCAN_AREA,
     int camera = CAMERA_BACK,
     double fps = 2.0,
   }) async {
@@ -91,6 +96,8 @@ class FlutterMobileVision {
       'showText': showText,
       'previewWidth': preview != null ? preview.width : PREVIEW.width,
       'previewHeight': preview != null ? preview.height : PREVIEW.height,
+      'scanAreaWidth': scanArea != null ? scanArea.width : SCAN_AREA.width,
+      'scanAreaHeight': scanArea != null ? scanArea.height : SCAN_AREA.height,
       'camera': camera,
       'fps': fps,
     };
@@ -109,6 +116,7 @@ class FlutterMobileVision {
     bool multiple = true,
     bool showText = true,
     Size preview = PREVIEW,
+    Size scanArea = SCAN_AREA,
     int camera = CAMERA_BACK,
     double fps = 15.0,
   }) async {
@@ -119,6 +127,8 @@ class FlutterMobileVision {
       'showText': showText,
       'previewWidth': preview != null ? preview.width : PREVIEW.width,
       'previewHeight': preview != null ? preview.height : PREVIEW.height,
+      'scanAreaWidth': scanArea != null ? scanArea.width : SCAN_AREA.width,
+      'scanAreaHeight': scanArea != null ? scanArea.height : SCAN_AREA.height,
       'camera': camera,
       'fps': fps,
     };


### PR DESCRIPTION
Allows users to specify the width and height of a rectangular "scan area" when calling FlutterMobileVision methods, like so:
`FlutterMobileVision.read(camera: _ocrCamera, waitTap: true, scanArea: Size(400, 250));`

Default scan area size is Size(0,0). When starting the CameraSourcePreview, a check is ran on scanArea dimensions. If either width or height is zero, the actual scanArea graphic is not added to the ScanAreaOverlay. The presence of this graphic is checked in OcrGraphicTracker. If a scan area graphic is found, text graphics will only be tracked / added to overlay if they are within the scan area. If no scan area graphic is found, the OCR detector operates on default behavior.

Admittedly, I have only used this forked version using `FlutterMobileVision.read(...)` with OCR. Additional testing is necessary with other methods (scan, face, etc.) and vision activities (barcode, face, etc.). However, I needed this feature for my own usage, and have seen several Issues associated with requests for this feature. Hopefully this is a good start for those who wish to make use of such a feature.
[Example screenshot of scan area](https://user-images.githubusercontent.com/31458646/104857361-17cd8780-58e6-11eb-9ab8-a0221fec0580.png)
